### PR TITLE
CI: Move unit-tests from Dockerfile to separate workflow job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,14 @@ jobs:
   lint:
     uses: heathcliff26/ci/.github/workflows/golang-lint.yaml@main
 
+  unit-tests:
+    uses: heathcliff26/ci/.github/workflows/golang-unit-tests.yaml@main
+
   build:
     uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
     needs:
       - lint
+      - unit-tests
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###############################################################################
 # BEGIN build-stage
 # Compile the binary
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22.5@sha256:829eff99a4b2abffe68f6a3847337bf6455d69d17e49ec1a97dac78834754bd6 AS build-stage
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22.5 AS build-stage
 
 ARG BUILDPLATFORM
 ARG TARGETARCH
@@ -20,30 +20,13 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build -ldflags="-w -s" -o
 ###############################################################################
 
 ###############################################################################
-# BEGIN test-stage
-# Run the tests in the container
-FROM docker.io/library/golang:1.22.5@sha256:829eff99a4b2abffe68f6a3847337bf6455d69d17e49ec1a97dac78834754bd6 AS test-stage
-
-WORKDIR /app
-
-COPY --from=build-stage /app /app
-# Not needed for testing, but needed for later stage
-COPY --from=build-stage /minecraft-exporter /
-
-RUN go test -v ./...
-
-#
-# END test-stage
-###############################################################################
-
-###############################################################################
 # BEGIN combine-stage
 # Combine all outputs, to enable single layer copy for the final image
 FROM scratch AS combine-stage
 
-COPY --from=test-stage /minecraft-exporter /
+COPY --from=build-stage /minecraft-exporter /
 
-COPY --from=test-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 #
 # END combine-stage


### PR DESCRIPTION
Additionally, drop digest pin for golang image, as it is not included in final image.