### PR TITLE
go.mod: Remove toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/heathcliff26/minecraft-exporter
 
 go 1.22
 
-toolchain go1.23.1
-
 require (
 	github.com/Tnze/go-mc v1.20.2
 	github.com/hashicorp/go-version v1.7.0


### PR DESCRIPTION
The toolchain directive was added with go1.22, since the go version has been bumped to it, there is no need to carry the toolchain directive.