### PR TITLE
go.mod: Update go version to 1.N.P notation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/heathcliff26/minecraft-exporter
 
-go 1.23
-
-toolchain go1.23.4
+go 1.23.0
 
 require (
 	github.com/Tnze/go-mc v1.20.2


### PR DESCRIPTION
According to CodeQL:
As of Go 1.21, toolchain versions must use the 1.N.P syntax.