### PR TITLE
version: Use the version from build info

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,5 +66,4 @@ jobs:
       tag: "${{ inputs.tag == '' && 'rolling' || inputs.tag }}"
       tags: "${{ inputs.latest == true && 'type=raw,value=latest' || '' }}"
       dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.dry-run == 'true' }}
-      build-args: "RELEASE_VERSION=${{ inputs.tag == '' && 'rolling' || inputs.tag }}"
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
 ###############################################################################
 # BEGIN build-stage
 # Compile the binary
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23.5 AS build-stage
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.0 AS build-stage
 
 ARG BUILDPLATFORM
 ARG TARGETARCH
-ARG RELEASE_VERSION
 
 WORKDIR /app
 
-COPY vendor ./vendor
-COPY go.mod go.sum ./
-COPY cmd ./cmd
-COPY pkg ./pkg
-COPY hack ./hack
+COPY . ./
 
-RUN --mount=type=bind,target=/app/.git,source=.git GOOS=linux GOARCH="${TARGETARCH}" hack/build.sh
+RUN GOOS=linux GOARCH="${TARGETARCH}" hack/build.sh
 
 #
 # END build-stage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heathcliff26/minecraft-exporter
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/Tnze/go-mc v1.20.2

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -11,11 +11,6 @@ GOARCH="${GOARCH:-$(go env GOARCH)}"
 
 GO_LD_FLAGS="${GO_LD_FLAGS:-"-s"}"
 
-if [ "${RELEASE_VERSION}" != "" ]; then
-    echo "Building release version ${RELEASE_VERSION}"
-    GO_LD_FLAGS+=" -X github.com/heathcliff26/minecraft-exporter/pkg/version.version=${RELEASE_VERSION}"
-fi
-
 output_name="${bin_dir}/minecraft-exporter"
 if [ "${GOOS}" == "windows" ]; then
     output_name="${output_name}.exe"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,8 +7,7 @@ import (
 
 const Name = "minecraft-exporter"
 
-var version = "devel"
-
+// Return a formated string containing the version, git commit and go version the app was compiled with.
 func Version() string {
 	var commit string
 	buildinfo, _ := debug.ReadBuildInfo()
@@ -25,7 +24,7 @@ func Version() string {
 	}
 
 	result := Name + ":\n"
-	result += "    Version: " + version + "\n"
+	result += "    Version: " + buildinfo.Main.Version + "\n"
 	result += "    Commit:  " + commit + "\n"
 	result += "    Go:      " + runtime.Version() + "\n"
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"testing"
 
@@ -15,11 +16,13 @@ func TestVersion(t *testing.T) {
 
 	assert := assert.New(t)
 
+	buildinfo, _ := debug.ReadBuildInfo()
+
 	if !assert.Equal(5, len(lines), "Should have enough lines") {
 		t.FailNow()
 	}
 	assert.Contains(lines[0], Name)
-	assert.Contains(lines[1], version)
+	assert.Contains(lines[1], buildinfo.Main.Version)
 
 	commit := strings.Split(lines[2], ":")
 	assert.NotEmpty(strings.TrimSpace(commit[1]))


### PR DESCRIPTION
With golang 1.24, the version derived from tag is now embedded by default. Use it instead, as it is better and easier than stamping it manually during build.
Ensure Dockerfile does not have a dirty repo by copying everything during build.
Require golang 1.24.