### PR TITLE
Use minecraft-exporter as default job name when pushing metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,7 +73,7 @@ func main() {
 	}
 
 	if cfg.Remote.Enable {
-		rwClient, err := promremote.NewWriteClient(cfg.Remote.URL, cfg.Remote.Instance, "integrations/minecraft-exporter", reg)
+		rwClient, err := promremote.NewWriteClient(cfg.Remote.URL, cfg.Remote.Instance, cfg.Remote.JobName, reg)
 		if err != nil {
 			slog.Error("Failed to create remote write client", "err", err)
 			os.Exit(1)

--- a/configs/example-config.yaml
+++ b/configs/example-config.yaml
@@ -33,6 +33,8 @@ remote:
   url: ""
   # Name of the instance, used to label metrics when performing remote_write. Defaults to hostname when empty
   instance: ""
+  # Name of job under which metrics will be pushed
+  jobName: "minecraft-exporter"
   # Username and password for Basic Authentication. Leave empty when not required
   username: ""
   password: ""

--- a/dashboard/player.json
+++ b/dashboard/player.json
@@ -749,14 +749,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values({job=\"integrations/minecraft-exporter\"},instance)",
+        "definition": "label_values({job=\"minecraft-exporter\"},instance)",
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values({job=\"integrations/minecraft-exporter\"},instance)",
+          "query": "label_values({job=\"minecraft-exporter\"},instance)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/dashboard/server.json
+++ b/dashboard/server.json
@@ -1103,14 +1103,14 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values({job=\"integrations/minecraft-exporter\"},instance)",
+        "definition": "label_values({job=\"minecraft-exporter\"},instance)",
         "includeAll": true,
         "label": "Instance",
         "multi": true,
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values({job=\"integrations/minecraft-exporter\"},instance)",
+          "query": "label_values({job=\"minecraft-exporter\"},instance)",
           "refId": "prometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,10 +11,14 @@ import (
 )
 
 const (
-	DEFAULT_LOG_LEVEL    = "info"
-	DEFAULT_PORT         = 8080
-	DEFAULT_INTERVAL     = Duration(1 * time.Minute)
-	DEFAULT_WORLD_DIR    = "/world"
+	DEFAULT_LOG_LEVEL       = "info"
+	DEFAULT_PORT            = 8080
+	DEFAULT_INTERVAL        = Duration(1 * time.Minute)
+	DEFAULT_WORLD_DIR       = "/world"
+	DEFAULT_REMOTE_JOB_NAME = "minecraft-exporter"
+)
+
+const (
 	SERVER_TYPE_VANILLA  = "vanilla"
 	SERVER_TYPE_FORGE    = "forge"
 	SERVER_TYPE_PAPER    = "paper"
@@ -56,6 +60,7 @@ type RemoteConfig struct {
 	Enable   bool   `json:"enable"`
 	URL      string `json:"url"`
 	Instance string `json:"instance"`
+	JobName  string `json:"jobName,omitempty"`
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
 }
@@ -68,6 +73,9 @@ func DefaultConfig() Config {
 		Interval:   DEFAULT_INTERVAL,
 		ServerType: SERVER_TYPE_VANILLA,
 		WorldDir:   DEFAULT_WORLD_DIR,
+		Remote: RemoteConfig{
+			JobName: DEFAULT_REMOTE_JOB_NAME,
+		},
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,6 +23,9 @@ func TestValidConfigs(t *testing.T) {
 			Port:     25575,
 			Password: "password",
 		},
+		Remote: RemoteConfig{
+			JobName: DEFAULT_REMOTE_JOB_NAME,
+		},
 	}
 	c2 := Config{
 		LogLevel:   "debug",
@@ -34,6 +37,7 @@ func TestValidConfigs(t *testing.T) {
 			Enable:   true,
 			URL:      "https://example.org/",
 			Instance: "test",
+			JobName:  "testjob",
 			Username: "somebody",
 			Password: "somebody's password",
 		},
@@ -48,6 +52,7 @@ func TestValidConfigs(t *testing.T) {
 			Enable:   true,
 			URL:      "https://example.org/",
 			Instance: "test",
+			JobName:  "testjob",
 		},
 	}
 	tMatrix := []struct {
@@ -142,6 +147,9 @@ func TestEnvSubstitution(t *testing.T) {
 		Interval:   Duration(time.Minute),
 		ServerType: SERVER_TYPE_VANILLA,
 		WorldDir:   "/some/server/world",
+		Remote: RemoteConfig{
+			JobName: DEFAULT_REMOTE_JOB_NAME,
+		},
 	}
 	t.Setenv("MINECRAFT_EXPORTER_LOG_LEVEL", c.LogLevel)
 	t.Setenv("MINECRAFT_EXPORTER_PORT", strconv.Itoa(c.Port))

--- a/pkg/config/testdata/valid-config-2.yaml
+++ b/pkg/config/testdata/valid-config-2.yaml
@@ -5,5 +5,6 @@ remote:
   enable: true
   url: "https://example.org/"
   instance: "test"
+  jobName: "testjob"
   username: "somebody"
   password: "somebody's password"

--- a/pkg/config/testdata/valid-config-3.yaml
+++ b/pkg/config/testdata/valid-config-3.yaml
@@ -3,3 +3,4 @@ remote:
   enable: true
   url: "https://example.org/"
   instance: "test"
+  jobName: "testjob"


### PR DESCRIPTION
Make the job name more intuitive through dropping the integrations prefix.
Allow configuring the job name through config file.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>